### PR TITLE
fix: editor.js module not found

### DIFF
--- a/bud.config.js
+++ b/bud.config.js
@@ -31,17 +31,6 @@ module.exports = (app) =>
       'app/View/**/*.php',
     ])
 
-    .experiments('lazyCompilation', {
-      // disable lazy compilation for dynamic imports
-      imports: false,
-
-      // disable lazy compilation for entries
-      entries: false,
-
-      // do not lazily compile moduleB
-      test: (module) => !/moduleB/.test(module.nameForCondition()),
-    })
-
     /**
      * Target URL to be proxied by the dev server.
      *

--- a/resources/scripts/editor.js
+++ b/resources/scripts/editor.js
@@ -1,18 +1,18 @@
-import {registerBlockStyle, unregisterBlockStyle} from '@wordpress/blocks';
+// import {registerBlockStyle, unregisterBlockStyle} from '@wordpress/blocks';
 
-import {domReady} from '@scripts/components';
+// import {domReady} from '@scripts/components';
 
 /**
  * Customize block styles
  */
-domReady(() => {
+/* domReady(() => {
   unregisterBlockStyle('core/button', 'outline');
 
   registerBlockStyle('core/button', {
     name: 'outline',
     label: 'Outline',
   });
-});
+}); */
 
 /**
  * Accept module updates


### PR DESCRIPTION
nothing wrong with babel config. you don't need to do anything unless you need a polyfill for your target browsers.

`@scripts/editor.js` is trying to import a component that doesn't exist.